### PR TITLE
[RETINA-264] Fastclick Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "vue-lazyload": "^1.2.6",
     "vue-mq": "^0.2.1",
     "vue-notifications": "^0.9.0",
+    "vue-svgicon": "^3.2.1",
     "vuex": "^3.0.1"
   },
   "devDependencies": {
@@ -71,7 +72,6 @@
     "vue": "^2.5.16",
     "vue-hot-reload-api": "^2.3.0",
     "vue-router": "^3.0.1",
-    "vue-svgicon": "^3.2.1",
     "vue-template-compiler": "^2.5.16"
   },
   "cordova": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cordova-ios": "^4.5.5",
     "cordova-plugin-device": "^2.0.2",
     "cordova-plugin-printer": "^0.7.3",
-    "fastclick": "^1.0.6",
+    "fastclick": "https://github.com/Renascentinc/fastclick.git",
     "graphql": "^14.0.2",
     "graphql-tag": "^2.10.0",
     "html2pdf.js": "^0.9.0",
@@ -45,7 +45,6 @@
     "vue-lazyload": "^1.2.6",
     "vue-mq": "^0.2.1",
     "vue-notifications": "^0.9.0",
-    "vue-snotify": "^3.2.1",
     "vuex": "^3.0.1"
   },
   "devDependencies": {

--- a/src/components/config-item.vue
+++ b/src/components/config-item.vue
@@ -153,37 +153,37 @@ export default {
   @import '../styles/variables';
   @import '../styles/search-result';
 
-  .sanctioned {
-    .save-icon, .cancel-icon {
-      color: $renascent-red;
-      font-size: 30px;
-    }
-  }
-
-  .unsanctioned {
-    background-color: $renascent-red;
-    color: white;
-
-    .edit-icon {
-      color: white !important;
-    }
-
-    .save-icon, .cancel-icon {
-      color: white;
-      font-size: 30px;
-    }
-
-    .action-group {
-      color: white !important;
-
-      .fab {
+  .search-result {
+    &.sanctioned {
+      .save-icon, .cancel-icon {
         color: $renascent-red;
-        background-color: white;
+        font-size: 30px;
       }
     }
-  }
 
-  .search-result {
+    &.unsanctioned {
+      background-color: $renascent-red;
+      color: white;
+
+      .edit-icon {
+        color: white !important;
+      }
+
+      .save-icon, .cancel-icon {
+        color: white;
+        font-size: 30px;
+      }
+
+      .action-group {
+        color: white !important;
+
+        .fab {
+          color: $renascent-red;
+          background-color: white;
+        }
+      }
+    }
+
     .element-container {
       padding-right: 10px;
     }
@@ -220,7 +220,7 @@ export default {
     .actions {
       display: flex;
       flex-direction: row;
-      flex: 1 1 50%;
+      flex: 0 0 50%;
       justify-content: space-around;
       height: 100%;
 
@@ -235,6 +235,7 @@ export default {
         color: $renascent-dark-gray;
         padding-top: 5px;
         padding-bottom: 5px;
+        width: 50px;
 
         .fab {
           height: 32px;

--- a/src/components/extended-fab.vue
+++ b/src/components/extended-fab.vue
@@ -2,7 +2,6 @@
   <button
     :class="{ outlined: outlineDisplay, inactive: disabled }"
     :disabled="disabled"
-    :type="buttonType"
     class="extended-fab"
     @click="onClick">
     <div class="fab-icon-container">
@@ -45,12 +44,6 @@ export default {
       type: Boolean,
       required: false,
       default: false
-    },
-
-    buttonType: {
-      type: String,
-      required: false,
-      default: ''
     }
   }
 }

--- a/src/components/extended-fab.vue
+++ b/src/components/extended-fab.vue
@@ -2,6 +2,7 @@
   <button
     :class="{ outlined: outlineDisplay, inactive: disabled }"
     :disabled="disabled"
+    :type="buttonType"
     class="extended-fab"
     @click="onClick">
     <div class="fab-icon-container">
@@ -44,6 +45,12 @@ export default {
       type: Boolean,
       required: false,
       default: false
+    },
+
+    buttonType: {
+      type: String,
+      required: false,
+      default: ''
     }
   }
 }

--- a/src/components/select.vue
+++ b/src/components/select.vue
@@ -111,9 +111,10 @@
         </li>
         <li
           v-if="!filteredOptions.length"
-          class="no-options">
+          class="no-options"
+          role="option">
           <slot
-            v-bind="{ value: search }"
+            v-bind="{ value: search, select }"
             name="no-options">Sorry, no matching options.</slot>
         </li>
       </ul>
@@ -815,7 +816,10 @@ export default {
         this.mousedown = false
       } else {
         if (this.clearSearchOnBlur) {
-          this.search = ''
+          setTimeout(() => {
+            this.search = ''
+            this.open = false
+          }, 100)
         }
         this.$emit('search:blur')
       }

--- a/src/components/select.vue
+++ b/src/components/select.vue
@@ -6,7 +6,7 @@
     <div
       ref="toggle"
       class="dropdown-toggle"
-      @mousedown.prevent="toggleDropdown">
+      @click="toggleDropdown">
 
       <div
         ref="selectedOptions"
@@ -94,31 +94,20 @@
         class="dropdown-menu"
         role="listbox"
         @mousedown="onMousedown">
-        <!-- <li
-          v-for="(option, index) in filteredOptions"
-          :key="index"
-          :class="{ active: isOptionSelected(option) }"
-          role="option">
-          <a @mousedown.prevent.stop="select(option)">
-            <slot
-              v-bind="(typeof option === 'object') ? option : { [label] : option }"
-              name="option">
-              {{ getOptionLabel(option) }}
-            </slot>
-          </a>
-        </li> -->
         <li
           v-for="(option, index) in filteredOptions"
           :key="index"
           :class="{ active: isOptionSelected(option) }"
           role="option">
-          <a @mousedown.prevent.stop="select(option)">
+          <button
+            class="option-container"
+            @click="select(option)">
             <slot
               v-bind="(typeof option === 'object') ? option : { [label] : option }"
               name="option">
               {{ getOptionLabel(option) }}
             </slot>
-          </a>
+          </button>
         </li>
         <li
           v-if="!filteredOptions.length"
@@ -740,16 +729,13 @@ export default {
        * @param  {Event} e
        * @return {void}
        */
-    toggleDropdown (e) {
-      if (e.target === this.$refs.openIndicator || e.target === this.$refs.search || e.target === this.$refs.toggle ||
-            e.target.classList.contains('selected-tag') || e.target === this.$el) {
+    toggleDropdown () {
+      this.open = !this.open
+      if (this.searchable) {
         if (this.open) {
-          this.$refs.search.blur() // dropdown will close on blur
+          this.$refs.search.focus()
         } else {
-          if (!this.disabled) {
-            this.open = true
-            this.$refs.search.focus()
-          }
+          this.$refs.search.blur()
         }
       }
     },
@@ -831,7 +817,6 @@ export default {
         if (this.clearSearchOnBlur) {
           this.search = ''
         }
-        this.open = false
         this.$emit('search:blur')
       }
     },
@@ -842,7 +827,6 @@ export default {
        * @return {void}
        */
     onSearchFocus () {
-      this.open = true
       this.$emit('search:focus')
     },
 
@@ -1127,9 +1111,6 @@ export default {
   }
 
   /* List Items */
-  .v-select li {
-    line-height: 1.42857143; /* Normalize line height */
-  }
   .v-select li > a {
     display: block;
     padding: 3px 20px;
@@ -1145,27 +1126,22 @@ export default {
     background: rgba(50, 50, 50, .1);
   }
 
-  /* Loading Spinner */
-  /* .v-select .spinner {
-    align-self: center;
-    opacity: 0;
-    font-size: 5px;
-    text-indent: -9999em;
-    overflow: hidden;
-    border-top: .9em solid rgba(100, 100, 100, .1);
-    border-right: .9em solid rgba(100, 100, 100, .1);
-    border-bottom: .9em solid rgba(100, 100, 100, .1);
-    border-left: .9em solid rgba(60, 60, 60, .45);
-    transform: translateZ(0);
-    animation: vSelectSpinner 1.1s infinite linear;
-    transition: opacity .1s;
+  .v-select .option-container {
+    height: 40px;
+    width: 100%;
+    text-align: left;
+    font-size: 20px;
+    font-weight: 700;
   }
-  .v-select .spinner,
-  .v-select .spinner:after {
-    border-radius: 50%;
-    width: 5em;
-    height: 5em;
-  } */
+
+  .v-select li.active {
+    /* background-color: #CE352F; */
+  }
+
+  .v-select li.active .option-container{
+    color: white;
+    background-color: #CE352F;
+  }
 
   /* Disabled state */
   .v-select.disabled .dropdown-toggle,
@@ -1176,35 +1152,4 @@ export default {
     cursor: not-allowed;
     background-color: rgb(248, 248, 248);
   }
-
-  /* Loading Spinner States */
-  /* .v-select.loading .spinner {
-    opacity: 1;
-  } */
-  /* KeyFrames */
-  /* @-webkit-keyframes vSelectSpinner {
-    0% {
-      transform: rotate(0deg);
-    }
-    100% {
-      transform: rotate(360deg);
-    }
-  }
-  @keyframes vSelectSpinner {
-    0% {
-      transform: rotate(0deg);
-    }
-    100% {
-      transform: rotate(360deg);
-    }
-  } */
-  /* Dropdown Default Transition */
-  /* .fade-enter-active,
-  .fade-leave-active {
-    transition: opacity .15s cubic-bezier(1.0, 0.5, 0.8, 1.0);
-  }
-  .fade-enter,
-  .fade-leave-to {
-    opacity: 0;
-  } */
 </style>

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ import VueLazyload from 'vue-lazyload'
 import App from './App'
 import router from './router'
 import store from './store'
-// import attachFastClick from 'fastclick'
+import attachFastClick from 'fastclick'
 import DrawerLayout from 'vue-drawer-layout'
 import { ApolloClient } from 'apollo-client'
 import { HttpLink } from 'apollo-link-http'
@@ -27,13 +27,6 @@ import swal from 'sweetalert'
 function toast ({title, message, type, timeout, cb}) {
   if (type === VueNotifications.types.warn) type = 'warning'
   return swal(title, message, type)
-}
-
-const options = {
-  success: toast,
-  error: toast,
-  info: toast,
-  warn: toast
 }
 
 const fragmentMatcher = new IntrospectionFragmentMatcher({
@@ -60,8 +53,8 @@ const fragmentMatcher = new IntrospectionFragmentMatcher({
 const cache = new InMemoryCache({
   fragmentMatcher,
   dataIdFromObject: object => {
-    // fixing issue on tools page where objects were getting scrambled with each other
-    // using a combination of fields to make a unique identifier for the entries
+    // fixing issue on history page where objects were getting scrambled with each other (same ids but different data at different snapshots in time).
+    // using a combination of fields to create a unique identifier for the entries
     if (object.__typename === 'PreviousToolSnapshotDiff' || (router.currentRoute.path === '/history' && object.__typename === 'Tool')) {
       return `${object.id}${object.__typename}${object.owner ? object.owner.id || object.owner.id : ''}${object.status}`
     }
@@ -69,6 +62,7 @@ const cache = new InMemoryCache({
   }
 })
 
+// TODO: dynamically switch between prod and develop api's
 const httpLink = new HttpLink({
   uri: 'http://retina-api-develop.us-east-2.elasticbeanstalk.com/graphql'
 })
@@ -111,19 +105,24 @@ Vue.use(DrawerLayout)
 Vue.use(VueApollo)
 Vue.use(VCalendar)
 Vue.use(VeeValidate)
+Vue.use(VueSVGIcon)
+Vue.use(VueJsModal, {
+  dialog: true
+})
+Vue.use(VueNotifications, {
+  success: toast,
+  error: toast,
+  info: toast,
+  warn: toast
+})
 Vue.use(VueMq, {
   breakpoints: {
     mobile: 500,
     desktop: Infinity
   }
 })
-Vue.use(VueSVGIcon)
-Vue.use(VueNotifications, options)
-Vue.use(VueJsModal, {
-  dialog: true
-})
 
-// attachFastClick(document.body, { tapDelay: 200 })
+attachFastClick(document.body, { tapDelay: 200 })
 
 new Vue({
   router,

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ import VueLazyload from 'vue-lazyload'
 import App from './App'
 import router from './router'
 import store from './store'
-import attachFastClick from 'fastclick'
+// import attachFastClick from 'fastclick'
 import DrawerLayout from 'vue-drawer-layout'
 import { ApolloClient } from 'apollo-client'
 import { HttpLink } from 'apollo-link-http'
@@ -123,7 +123,7 @@ Vue.use(VueJsModal, {
   dialog: true
 })
 
-attachFastClick(document.body)
+// attachFastClick(document.body, { tapDelay: 200 })
 
 new Vue({
   router,

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ import VueLazyload from 'vue-lazyload'
 import App from './App'
 import router from './router'
 import store from './store'
-// import attachFastClick from 'fastclick'
+import attachFastClick from 'fastclick'
 import DrawerLayout from 'vue-drawer-layout'
 import { ApolloClient } from 'apollo-client'
 import { HttpLink } from 'apollo-link-http'
@@ -123,7 +123,7 @@ Vue.use(VueJsModal, {
   dialog: true
 })
 
-// attachFastClick(document.body)
+attachFastClick(document.body)
 
 new Vue({
   router,

--- a/src/router.js
+++ b/src/router.js
@@ -4,16 +4,26 @@ import Login from './routes/login'
 import Application from './routes/application'
 import LandingPage from './routes/landing-page'
 
+// TODO: re-enable lazy loaded routes for final web deploy
 // lazy loaded routes
-const Tools = () => import('./routes/tools')
-const PasswordReset = () => import('./routes/password-reset')
-const Configuration = () => import('./routes/configuration')
-const History = () => import('./routes/history')
-const UserDetail = () => import('./routes/user-detail')
-const Users = () => import('./routes/users')
-const NewTool = () => import('./routes/new-tool')
-const ToolDetail = () => import('./routes/tool-detail')
-const NewUser = () => import('./routes/new-user')
+// const Tools = () => import('./routes/tools')
+// const PasswordReset = () => import('./routes/password-reset')
+// const Configuration = () => import('./routes/configuration')
+// const History = () => import('./routes/history')
+// const UserDetail = () => import('./routes/user-detail')
+// const Users = () => import('./routes/users')
+// const NewTool = () => import('./routes/new-tool')
+// const ToolDetail = () => import('./routes/tool-detail')
+// const NewUser = () => import('./routes/new-user')
+import Tools from './routes/tools'
+import PasswordReset from './routes/password-reset'
+import Configuration from './routes/configuration'
+import History from './routes/history'
+import UserDetail from './routes/user-detail'
+import Users from './routes/users'
+import NewTool from './routes/new-tool'
+import ToolDetail from './routes/tool-detail'
+import NewUser from './routes/new-user'
 
 Vue.use(Router)
 

--- a/src/routes/configuration.vue
+++ b/src/routes/configuration.vue
@@ -359,7 +359,6 @@ export default {
 
     finalizeDelete () {
       this.replacementList.forEach(tool => {
-        console.log(tool)
         this.$apollo
           .mutate({
             mutation: gql`
@@ -379,7 +378,7 @@ export default {
                 serial_number: tool.serial_number,
                 status: tool.status,
                 owner_id: tool.owner.id,
-                purchased_from_id: this.page === ConfigurableItems.PURCHASED_FROM ? this.replaceSupplierWith.id : tool.purchased_from.id,
+                purchased_from_id: this.page === ConfigurableItems.PURCHASED_FROM ? this.replaceSupplierWith.id : tool.purchased_from && tool.purchased_from.id,
                 date_purchased: tool.date_purchased,
                 photo: tool.photo,
                 price: tool.price,

--- a/src/routes/history.vue
+++ b/src/routes/history.vue
@@ -10,18 +10,16 @@
         :input-props="{ readonly: true }"
         :attributes="[{ popover: { visibility: 'hidden' } }]"
         :max-date="new Date()"
-        popover-visibility="focus"
+        :popover-visibility="datePickerVisibility"
         popover-direction="bottom"
         popover-align="right"
         mode="range"
-        @popover-did-appear="() => isDatepickerShown = true"
-        @popover-did-disappear="() => { isDatepickerShown = false; updateDateFilterTag() }">
-
+        @input="toggleDatepicker">
         <button
-          slot-scope="{ inputValue, updateValue }"
+          slot-scope="scope"
           :class="{ active: !!dateRange }"
           class="fas fa-calendar-alt open-datepicker"
-          @click="() => toggleDatepicker(inputValue, updateValue)">
+          @click="toggleDatepicker">
         </button>
       </v-date-picker>
     </div>
@@ -348,6 +346,9 @@ export default {
   },
 
   computed: {
+    datePickerVisibility () {
+      return this.isDatepickerShown ? 'visible' : 'hidden'
+    },
     isNativeApp () {
       return !!window.device && !!window.device.cordova
     },
@@ -392,8 +393,9 @@ export default {
       }
     },
 
-    toggleDatepicker (inputValue, updateValue) {
-      updateValue(inputValue, { formatInput: true, hidePopover: this.isDatepickerShown })
+    toggleDatepicker () {
+      this.isDatepickerShown = !this.isDatepickerShown
+      this.updateDateFilterTag()
     },
 
     exportTable () {

--- a/src/routes/history.vue
+++ b/src/routes/history.vue
@@ -103,30 +103,33 @@
             </div>
           </div>
 
-          <div class="loading-container">
+          <transition name="list-loading">
             <div
               v-if="$apollo.queries.searchToolHistory.loading"
-              class="loading">
+              class="loading-container">
+              <div
+                class="loading">
+              </div>
             </div>
-          </div>
+          </transition>
 
           <div
-            v-if="!$apollo.queries.searchToolHistory.loading"
             class="dt-body"
             style="display: flex;
               flex-direction: column;">
-            <div
-              v-for="entry in searchToolHistory"
-              :key="entry.id"
-              class="dt-row"
-              style="display: flex;
+            <transition-group name="list-element">
+              <div
+                v-for="entry in searchToolHistory"
+                :key="entry.id"
+                class="dt-row"
+                style="display: flex;
                 border-radius: 3px;
                 border-bottom: solid 1px lightgray;
                 background-color: white;
                 box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16);">
-              <div
-                class="dt-cell id"
-                style="display: flex;
+                <div
+                  class="dt-cell id"
+                  style="display: flex;
                   justify-content: flex-end;
                   flex: 0 0 50px;
                   justify-content: center;
@@ -135,103 +138,104 @@
                   align-items: center;
                   height: 85px;
                   font-weight: 900; border-right: solid 1px lightgray;">
-                <span>{{ entry.tool_snapshot.id }}</span>
-              </div>
-              <div
-                class="dt-cell date"
-                style="display: flex;
+                  <span>{{ entry.tool_snapshot.id }}</span>
+                </div>
+                <div
+                  class="dt-cell date"
+                  style="display: flex;
                   justify-content: flex-end;
                   display: flex;
                   align-items: center;
                   height: 85px;
                   font-weight: 900; flex: 0 0 200px;">
-                <span>{{ `${new Date(entry.timestamp).toLocaleDateString('en-US', { timeZone: 'UTC' })} ${new Date(entry.timestamp).toLocaleTimeString('en-US')}` }}</span>
-              </div>
-              <div
-                class="dt-cell action"
-                style="display: flex;
+                  <span>{{ `${new Date(entry.timestamp).toLocaleDateString('en-US', { timeZone: 'UTC' })} ${new Date(entry.timestamp).toLocaleTimeString('en-US')}` }}</span>
+                </div>
+                <div
+                  class="dt-cell action"
+                  style="display: flex;
                   justify-content: flex-end;
                   flex: 0 0 120px;
                   display: flex;
                   align-items: center;
                   height: 85px;
                   font-weight: 900;">
-                <span>{{ entry.tool_action }}</span>
-              </div>
-              <div
-                class="dt-cell status"
-                style="display: flex;
+                  <span>{{ entry.tool_action }}</span>
+                </div>
+                <div
+                  class="dt-cell status"
+                  style="display: flex;
                   justify-content: flex-end; flex: 0 0 270px;
                   display: flex;
                   align-items: center;
                   height: 85px;
                   font-weight: 900;">
-                <span
-                  v-if="entry.previous_tool_snapshot_diff.status"
-                  class="previous-snapshot"
-                  style="color: gray;">{{ entry.previous_tool_snapshot_diff.status }}</span>
-                <i
-                  v-if="entry.previous_tool_snapshot_diff.status"
-                  class="fas fa-long-arrow-alt-right"
-                  style="margin: 0 10px; content: '\f30b'"></i>
+                  <span
+                    v-if="entry.previous_tool_snapshot_diff.status"
+                    class="previous-snapshot"
+                    style="color: gray;">{{ entry.previous_tool_snapshot_diff.status }}</span>
+                  <i
+                    v-if="entry.previous_tool_snapshot_diff.status"
+                    class="fas fa-long-arrow-alt-right"
+                    style="margin: 0 10px; content: '\f30b'"></i>
 
-                <span>{{ entry.tool_snapshot.status }}</span>
+                  <span>{{ entry.tool_snapshot.status }}</span>
 
-              </div>
-              <div
-                class="dt-cell owner"
-                style="display: flex;
+                </div>
+                <div
+                  class="dt-cell owner"
+                  style="display: flex;
                   justify-content: flex-end;
                   flex: 0 0 260px;
                   display: flex;
                   align-items: center;
                   height: 85px;
                   font-weight: 900;">
-                <div v-if="entry.previous_tool_snapshot_diff.owner">
-                  <div
-                    v-if="entry.previous_tool_snapshot_diff.owner.type === 'USER'"
-                    class="owner-entry previous-snapshot"
-                    style="color: gray;
+                  <div v-if="entry.previous_tool_snapshot_diff.owner">
+                    <div
+                      v-if="entry.previous_tool_snapshot_diff.owner.type === 'USER'"
+                      class="owner-entry previous-snapshot"
+                      style="color: gray;
                       text-align: center;
                       max-width: 125px;
                       word-break: break-all;">
-                    {{ `${entry.previous_tool_snapshot_diff.owner.first_name} ${entry.previous_tool_snapshot_diff.owner.last_name}` }}
-                  </div>
-                  <div
-                    v-if="entry.previous_tool_snapshot_diff.owner.type === 'LOCATION'"
-                    class="owner-entry previous-snapshot"
-                    style="color: gray;
+                      {{ `${entry.previous_tool_snapshot_diff.owner.first_name} ${entry.previous_tool_snapshot_diff.owner.last_name}` }}
+                    </div>
+                    <div
+                      v-if="entry.previous_tool_snapshot_diff.owner.type === 'LOCATION'"
+                      class="owner-entry previous-snapshot"
+                      style="color: gray;
                       text-align: center;
                       max-width: 125px;
                       word-break: break-all;">
-                    <i class="fas fa-map-marker-alt"></i>
-                    {{ entry.previous_tool_snapshot_diff.owner.name }}
+                      <i class="fas fa-map-marker-alt"></i>
+                      {{ entry.previous_tool_snapshot_diff.owner.name }}
+                    </div>
                   </div>
-                </div>
 
-                <i
-                  v-if="entry.previous_tool_snapshot_diff.owner"
-                  class="fas fa-long-arrow-alt-right"
-                  style="margin: 0 10px; content: '\f30b'"></i>
+                  <i
+                    v-if="entry.previous_tool_snapshot_diff.owner"
+                    class="fas fa-long-arrow-alt-right"
+                    style="margin: 0 10px; content: '\f30b'"></i>
 
-                <div
-                  v-if="entry.tool_snapshot.owner.type === 'USER'"
-                  class="owner-entry"
-                  style="text-align: center;
+                  <div
+                    v-if="entry.tool_snapshot.owner.type === 'USER'"
+                    class="owner-entry"
+                    style="text-align: center;
                     max-width: 125px;
                     word-break: break-all;">
-                  {{ `${entry.tool_snapshot.owner.first_name} ${entry.tool_snapshot.owner.last_name}` }}
-                </div>
-                <div
-                  v-if="entry.tool_snapshot.owner.type === 'LOCATION'"
-                  class="owner-entry"
-                  style="text-align: center;
+                    {{ `${entry.tool_snapshot.owner.first_name} ${entry.tool_snapshot.owner.last_name}` }}
+                  </div>
+                  <div
+                    v-if="entry.tool_snapshot.owner.type === 'LOCATION'"
+                    class="owner-entry"
+                    style="text-align: center;
                     max-width: 125px;
                     word-break: break-all;">
-                  {{ entry.tool_snapshot.owner.name }}
+                    {{ entry.tool_snapshot.owner.name }}
+                  </div>
                 </div>
               </div>
-            </div>
+            </transition-group>
           </div>
         </div>
       </div>
@@ -449,9 +453,13 @@ export default {
 
 .desktop {
   .history-page {
+    .loading-container {
+      max-width: 100%;
+    }
+
     .search-bar {
       background-color: #fff;
-      width: calc(100% - 70px);
+      width: calc(100vw - 80px);
     }
 
     .search-input {
@@ -524,7 +532,6 @@ export default {
   .search-bar {
     background-color: #fff;
     padding: 10px;
-    min-height: 45px;
     box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.25);
     z-index: 5;
     display: flex;

--- a/src/routes/history.vue
+++ b/src/routes/history.vue
@@ -539,11 +539,13 @@ export default {
   .export-btn {
     position: absolute;
     right: 30px;
+    pointer-events: auto;
   }
 
   .print-btn {
     position: absolute;
     right: 30px;
+    pointer-events: auto;
   }
 }
 </style>

--- a/src/routes/history.vue
+++ b/src/routes/history.vue
@@ -450,6 +450,7 @@ export default {
 .desktop {
   .history-page {
     .search-bar {
+      background-color: #fff;
       width: calc(100% - 70px);
     }
 
@@ -521,6 +522,7 @@ export default {
   }
 
   .search-bar {
+    background-color: #fff;
     padding: 10px;
     min-height: 45px;
     box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.25);

--- a/src/routes/landing-page.vue
+++ b/src/routes/landing-page.vue
@@ -25,6 +25,7 @@ export default {
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  background-color: #fff;
 
   .logo {
     height: 30vh;

--- a/src/routes/login.vue
+++ b/src/routes/login.vue
@@ -18,7 +18,7 @@
         </span>
       </div>
     </div>
-    <form class="bottom-panel">
+    <div class="bottom-panel">
       <div class="status-message">
         <transition name="fade">
           <span
@@ -78,11 +78,10 @@
           :on-click="attemptUserLogin"
           class="login-btn"
           icon-class="fa-arrow-right"
-          button-text="SIGN IN"
-          button-type="submit">
+          button-text="SIGN IN">
         </extended-fab>
       </div>
-    </form>
+    </div>
 
     <modal
       :width="300"

--- a/src/routes/login.vue
+++ b/src/routes/login.vue
@@ -18,7 +18,7 @@
         </span>
       </div>
     </div>
-    <div class="bottom-panel">
+    <form class="bottom-panel">
       <div class="status-message">
         <transition name="fade">
           <span
@@ -69,6 +69,7 @@
       <div class="login-action-row">
         <button
           class="reset-password"
+          type="reset"
           @click="() => $modal.show('password-reset-modal')">
           RESET PASSWORD
         </button>
@@ -77,10 +78,11 @@
           :on-click="attemptUserLogin"
           class="login-btn"
           icon-class="fa-arrow-right"
-          button-text="SIGN IN">
+          button-text="SIGN IN"
+          button-type="submit">
         </extended-fab>
       </div>
-    </div>
+    </form>
 
     <modal
       :width="300"
@@ -304,6 +306,7 @@ $login-input-border-radius: 5px;
 .login-page {
   display: flex;
   flex-direction: column;
+  background-color: #fff;
 
   .top-panel {
     display: flex;

--- a/src/routes/new-tool.vue
+++ b/src/routes/new-tool.vue
@@ -182,18 +182,17 @@
             :input-props="{ readonly: true }"
             :attributes="[{ popover: { visibility: 'hidden' } }]"
             :max-date="new Date()"
-            popover-visibility="focus"
+            :popover-visibility="datePickerVisibility"
             popover-direction="top"
-            mode="single">
-            <input
-              slot-scope="{ inputValue, updateValue }"
-              :value="inputValue"
-              :placeholder="`eg. ${new Date().toLocaleDateString('en-US')}`"
-              disabled
-              type="text"
-              @input="updateValue($event.target.value, { formatInput: false, hidePopover: false })"
-              @change="updateValue($event.target.value, { formatInput: true, hidePopover: false })"
-              @keyup.esc="updateValue(myDate, { formatInput: true, hidePopover: true })">
+            mode="single"
+            @input="toggleDatepicker">
+              <button
+                slot-scope="{ inputValue, updateValue }"
+                :class="{ placeholder: !inputValue }"
+                class="dark-input purchase-date-input"
+                @click="toggleDatepicker">
+                {{ inputValue || `eg. ${new Date().toLocaleDateString('en-US')}` }}
+              </button>
           </v-date-picker>
         </div>
 
@@ -228,8 +227,10 @@
           v-if="!imgSrc"
           for="file"
           class="dark-input add-photo">
-          <i class="fas fa-camera"></i>
-          <span> Add Photo </span>
+          <label
+            for="file"
+            class="fas fa-camera"></label>
+          Add Photo
         </label>
 
         <img
@@ -394,8 +395,9 @@ export default {
       price: null,
       photo: null,
       status: statuses[1],
-      currentState: 1,
+      currentState: 2,
       purchaseDate: null,
+      datePickerVisibility: 'hidden',
       getAllConfigurableItem: [],
       getAllUser: [],
       tool: null,
@@ -433,6 +435,14 @@ export default {
   },
 
   methods: {
+    toggleDatepicker() {
+      if (this.datePickerVisibility === 'visible') {
+        this.datePickerVisibility = 'hidden'
+      } else {
+        this.datePickerVisibility = 'visible'
+      }
+    },
+
     updateImageDisplay () {
       this.imgSrc = window.URL.createObjectURL(this.$refs.file.files[0])
     },
@@ -624,6 +634,14 @@ export default {
   flex-direction: column;
   background-color: $background-light-gray;
 
+  .purchase-date-input {
+    text-align: left;
+
+    &.placeholder {
+      color: $form-placeholder-color;
+    }
+  }
+
   .new-tool-input-card {
     display: flex;
     flex: 1 1 auto;
@@ -761,7 +779,7 @@ export default {
     justify-content: center;
     height: 250px;
 
-    i {
+    .fa-camera {
       margin-right: 5px;
     }
 

--- a/src/routes/new-tool.vue
+++ b/src/routes/new-tool.vue
@@ -24,8 +24,8 @@
               slot="no-options"
               slot-scope="props">
               <button
-                class="no-options-btn"
-                @click="() => brand = { name: props.value, type: 'BRAND', isNewConfigurableItem: true }">
+                class="option-container"
+                @click="() => props.select({ name: props.value, type: 'BRAND', isNewConfigurableItem: true })">
                 Set Brand To "{{ props.value }}"
               </button>
             </template>
@@ -54,7 +54,7 @@
               slot-scope="props">
               <button
                 class="no-options-btn"
-                @click="() => type = { name: props.value, type: 'TYPE', isNewConfigurableItem: true }">
+                @click="() => props.select({ name: props.value, type: 'BRAND', isNewConfigurableItem: true })">
                 Set Type To "{{ props.value }}"
               </button>
             </template>
@@ -158,7 +158,7 @@
               slot-scope="props">
               <button
                 class="no-options-btn"
-                @click="() => purchasedFrom = { name: props.value, type: 'PURCHASED_FROM', isNewConfigurableItem: true }">
+                @click="() => props.select({ name: props.value, type: 'BRAND', isNewConfigurableItem: true })">
                 Set Purchased From To "{{ props.value }}"
               </button>
             </template>
@@ -801,6 +801,7 @@ export default {
   font-size: 23px;
   font-weight: 700;
   word-break: break-word;
+  width: 100%;
 }
 
 .desktop {

--- a/src/routes/new-tool.vue
+++ b/src/routes/new-tool.vue
@@ -186,13 +186,13 @@
             popover-direction="top"
             mode="single"
             @input="toggleDatepicker">
-              <button
-                slot-scope="{ inputValue, updateValue }"
-                :class="{ placeholder: !inputValue }"
-                class="dark-input purchase-date-input"
-                @click="toggleDatepicker">
-                {{ inputValue || `eg. ${new Date().toLocaleDateString('en-US')}` }}
-              </button>
+            <button
+              slot-scope="{ inputValue, updateValue }"
+              :class="{ placeholder: !inputValue }"
+              class="dark-input purchase-date-input"
+              @click="toggleDatepicker">
+              {{ inputValue || `eg. ${new Date().toLocaleDateString('en-US')}` }}
+            </button>
           </v-date-picker>
         </div>
 
@@ -435,7 +435,7 @@ export default {
   },
 
   methods: {
-    toggleDatepicker() {
+    toggleDatepicker () {
       if (this.datePickerVisibility === 'visible') {
         this.datePickerVisibility = 'hidden'
       } else {

--- a/src/routes/new-tool.vue
+++ b/src/routes/new-tool.vue
@@ -395,7 +395,7 @@ export default {
       price: null,
       photo: null,
       status: statuses[1],
-      currentState: 2,
+      currentState: 1,
       purchaseDate: null,
       datePickerVisibility: 'hidden',
       getAllConfigurableItem: [],

--- a/src/routes/tool-detail.vue
+++ b/src/routes/tool-detail.vue
@@ -938,6 +938,7 @@ export default {
       }
 
       .name {
+        word-break: break-word;
         font-size: 33px;
         font-weight: 900;
         text-align: center;

--- a/src/routes/tools.vue
+++ b/src/routes/tools.vue
@@ -455,6 +455,7 @@ export default {
   flex-direction: column;
 
   .search-bar {
+    background-color: #fff;
     padding: 10px;
     box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.25);
     z-index: 5;

--- a/src/routes/tools.vue
+++ b/src/routes/tools.vue
@@ -75,30 +75,31 @@
         </div>
       </transition>
       <div class="tool-scroll-container">
-        <transition>
+        <transition name="list-loading">
           <div
             v-if="$apollo.queries.searchTool.loading"
             class="loading-container">
             <div class="loading"></div>
           </div>
         </transition>
-        <transition-group>
-          <add-button
-            v-if="$mq === 'mobile'"
-            :key="0"
-            :on-click="transitionToAdd"
-            text="TOOL">
-          </add-button>
+        <add-button
+          v-if="$mq === 'mobile'"
+          :key="0"
+          :on-click="transitionToAdd"
+          text="TOOL">
+        </add-button>
+
+        <transition name="fade">
           <div
             v-if="!$apollo.queries.searchTool.loading && !tools.length"
             :key="1"
             class="no-tools-container">
             <span class="no-tools-text">No Tools To Display</span>
           </div>
-        </transition-group>
+        </transition>
 
         <transition-group
-          name="list"
+          name="list-element"
           tag="span">
           <tool-search-result
             v-for="tool in tools"
@@ -181,6 +182,7 @@
 </template>
 
 <script>
+import VueNotifications from 'vue-notifications'
 import ToolSearchInput from '../components/tool-search-input'
 import ToolSearchResult from '../components/tool-search-result'
 import ExtendedFab from '../components/extended-fab'
@@ -200,6 +202,14 @@ export default {
     vSelect,
     NfcScan,
     AddButton
+  },
+
+  notifications: {
+    showTransferSuccessMsg: {
+      type: VueNotifications.types.success,
+      title: 'TRANSFER SUCCESS',
+      message: 'Successfully Transferred Tools'
+    }
   },
 
   apollo: {
@@ -436,6 +446,7 @@ export default {
         this.$store.commit('resetSelectedTools')
         this.showOnlySelectedTools = false
         this.currentState = this.states.INITIAL
+        this.showTransferSuccessMsg()
       })
     },
 
@@ -465,6 +476,7 @@ export default {
   }
 
   .tools-menu-container {
+    display: flex;
     overflow-y: auto;
     background-color: $background-light-gray;
     flex: 1 1 auto;
@@ -513,14 +525,6 @@ export default {
       position: absolute;
       right: 20px;
     }
-  }
-
-  .loading-container {
-    display: flex;
-    justify-content: flex-start;
-    align-items: center;
-    width: 100%;
-    min-height: 40px;
   }
 
   .selection-action-bar {

--- a/src/routes/tools.vue
+++ b/src/routes/tools.vue
@@ -476,7 +476,6 @@ export default {
   }
 
   .tools-menu-container {
-    display: flex;
     overflow-y: auto;
     background-color: $background-light-gray;
     flex: 1 1 auto;
@@ -646,7 +645,7 @@ export default {
 
 .desktop {
   .tools-menu-container {
-    display: flex;
+    display: flex !important;
     height: 100%;
     flex-direction: row;
 

--- a/src/routes/tools.vue
+++ b/src/routes/tools.vue
@@ -502,6 +502,7 @@ export default {
 
     .transfer-btn {
       position: absolute;
+      pointer-events: auto;
       left: calc(50% - 79px);
       bottom: 3.5px;
       z-index: 1;
@@ -619,6 +620,7 @@ export default {
 
   .floating-action-bar {
     display: inline-block;
+    pointer-events: none;
     position: absolute;
     bottom: 75px;
     width: 100%;
@@ -627,14 +629,10 @@ export default {
 
     .transfer-btn {
       position: absolute;
+      pointer-events: auto;
       left: calc(50% - 79px);
       bottom: 3.5px;
       width: 158px;
-    }
-
-    .add-btn {
-      position: absolute;
-      right: 20px;
     }
   }
 }

--- a/src/routes/users.vue
+++ b/src/routes/users.vue
@@ -15,27 +15,27 @@
         </extended-fab>
       </div>
       <div class="user-scroll-container">
-        <transition>
+        <transition name="list-loading">
           <div
             v-if="$apollo.queries.searchUser.loading"
             class="loading-container">
             <div class="loading"/>
           </div>
         </transition>
-        <transition-group>
-          <add-button
-            v-if="$mq === 'mobile'"
-            :key="0"
-            :on-click="transitionToAddUser"
-            text="USER">
-          </add-button>
+        <add-button
+          v-if="$mq === 'mobile'"
+          :key="0"
+          :on-click="transitionToAddUser"
+          text="USER">
+        </add-button>
+        <transition name="fade">
           <div
             v-if="!$apollo.queries.searchUser.loading && !users.length"
             :key="1"
             class="no-users-container">
             <span class="no-users-text">No Users To Display</span>
           </div>
-        </transition-group>
+        </transition>
 
         <transition-group
           name="list"
@@ -195,15 +195,15 @@ export default {
     padding-top: 50px;
   }
 
-  .loading-container {
-    display: flex;
-    justify-content: flex-start;
-    align-items: center;
-    position: absolute;
-    top: 100px;
-    left: 0;
-    width: 100vw;
-  }
+  // .loading-container {
+  //   display: flex;
+  //   justify-content: flex-start;
+  //   align-items: center;
+  //   position: absolute;
+  //   top: 100px;
+  //   left: 0;
+  //   width: 100vw;
+  // }
 }
 
 .dark-dropdown {

--- a/src/routes/users.vue
+++ b/src/routes/users.vue
@@ -38,7 +38,7 @@
         </transition>
 
         <transition-group
-          name="list"
+          name="list-element"
           class="users"
           tag="div">
           <user-search-result

--- a/src/routes/users.vue
+++ b/src/routes/users.vue
@@ -159,6 +159,7 @@ export default {
   flex-direction: column;
 
   .search-bar {
+    background-color: #fff;
     padding: 10px;
     min-height: 45px;
     box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.25);

--- a/src/styles/add-button.scss
+++ b/src/styles/add-button.scss
@@ -49,6 +49,7 @@
   .container {
     font-size: 18px;
     height: 60px;
+    min-height: 60px;
 
     input {
       font-size: 20px;

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -23,6 +23,10 @@ html, body, #app {
   overflow: hidden;
 }
 
+body {
+  background-color: $renascent-dark-gray;
+}
+
 button {
   outline: none;
   border: none;

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -5,6 +5,7 @@
 @import 'navbar';
 @import 'form-inputs';
 @import 'toast';
+@import 'transitions';
 
 * {
   font-family: $font-family;
@@ -21,10 +22,6 @@ html, body, #app {
   height: 100%;
   margin: 0;
   overflow: hidden;
-}
-
-body {
-  background-color: $renascent-dark-gray;
 }
 
 button {
@@ -56,7 +53,8 @@ a {
   opacity: 0;
 }
 
-.page-change-leave-to {
+.page-change-leave-to,
+.page-change-leave-active {
   display: none;
 }
 

--- a/src/styles/search-input.scss
+++ b/src/styles/search-input.scss
@@ -23,6 +23,15 @@
     border-radius: 5px;
     max-width: 100% !important;
 
+    .selected-item {
+      background-color: $renascent-red;
+
+      .item-name,
+      .item-category {
+        color: #fff;
+      }
+    }
+
     .input {
       border: none;
 

--- a/src/styles/search-result.scss
+++ b/src/styles/search-result.scss
@@ -22,6 +22,7 @@ $tool-search-result-border-radius: 3px;
       flex: 1 1 auto;
 
       .title {
+        word-break: break-word;
         font-weight: 900;
         margin-bottom: 5px;
       }

--- a/src/styles/transitions.scss
+++ b/src/styles/transitions.scss
@@ -1,0 +1,39 @@
+.loading-container {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  width: 100%;
+  max-height: 40px;
+  height: 40px;
+  max-width: 500px;
+  flex: 0 0 40px;
+}
+
+.list-loading-enter-active, .list-loading-leave-active {
+  transition: all .15s ease;
+  height: 40px;
+}
+.list-loading-enter, .list-loading-leave-to {
+  opacity: 0;
+  height: 0;
+}
+
+.list-element-move {
+  transition: transform .5s ease;
+}
+
+.list-element-enter-active {
+  transition: all .5s ease;
+}
+.list-element-enter {
+  opacity: 0;
+}
+
+.list-element-leave-active {
+  display: none !important;
+  transition: all .2s ease;
+}
+
+.list-element-leave-to {
+  height: 0;
+}


### PR DESCRIPTION
And we are back : ) These are fixes for click issues that were preventing us from using fastclick. However I am going to still leave fastclick disabled until you guys can test out and actual device with fastclick. I believe that I have everything working with fastclick enabled however input elements still require a slightly longer tap than all other elements. Everything else however has much faster performance. 

Issues that Should be Addressed in this PR
- Fix small styling issues for config page (things would shift slight when going from sanctioned to unsanctioned because of different text lengths
- Fix issue where clicking right next to the transfer button would not select the tool search entry (would just do nothing)
- Improve how we handle logic for hiding and showing the date picker popover on the history page and the new tools page
- Fix dropdowns to get rid of squirrelly issues when opening/closing
- Disable lazy loaded routes for now. We can re-enable for the final web deploy but I don't think we want it for the cordova version
- Clicking the actual text for the `Add Photo` button would not do anything