### PR TITLE
v3.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "retina",
-  "version": "3.6.0-alpha.0",
+  "version": "3.5.1",
   "private": true,
   "description": "Renascent inc. Asset Tracking Application",
   "author": "Renascent Inc.",


### PR DESCRIPTION
Update splashscreen to meet iOS requirements, and build scaffolding should we choose to allow iOS devices to encode NFC tags.